### PR TITLE
Use object shorthand for properties

### DIFF
--- a/mqemitter.js
+++ b/mqemitter.js
@@ -21,7 +21,7 @@ function MQEmitter (opts) {
   this._messageCallbacks = []
   this._parallel = fastparallel({
     results: false,
-    released: released
+    released
   })
 
   this.concurrency = opts.concurrency || 0

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const mq = require('../')
 
 require('../abstractTest')({
   builder: mq,
-  test: test
+  test
 })
 
 test('queue concurrency', function (t) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166
