### PR TITLE
Make removeListener notify arg optional & fix TS declarations

### DIFF
--- a/mqemitter.d.ts
+++ b/mqemitter.d.ts
@@ -4,9 +4,9 @@
 
 /// <reference types="node" />
 
-declare function MQEmitter (options?: MQEmitterOptions): MQEmitter
+export default function MQEmitter (options?: MQEmitterOptions): MQEmitter
 
-interface MQEmitterOptions {
+export interface MQEmitterOptions {
   concurrency?: number
   matchEmptyLevels?: boolean
   separator?: string
@@ -20,7 +20,7 @@ export interface MQEmitter {
   current: number
   concurrent: number
   on(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): this
-  emit(topic: string, callback?: (error?: Error) => void): void
-  removeListener(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): void
+  emit(message: Message, callback?: (error?: Error) => void): void
+  removeListener(topic: string, listener?: (message: Message, done: () => void) => void, callback?: () => void): void
   close(callback: () => void): void
 }

--- a/mqemitter.js
+++ b/mqemitter.js
@@ -70,7 +70,6 @@ MQEmitter.prototype.on = function on (topic, notify, done) {
 
 MQEmitter.prototype.removeListener = function removeListener (topic, notify, done) {
   assert(topic)
-  assert(notify)
   this._matcher.remove(topic, notify)
 
   if (done) {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 /* eslint no-undef: 0 */
 
-import { MQEmitter, Message } from '../../mqemitter'
+import MQEmitter, { Message } from '../../mqemitter'
 
 const noop = function () {}
 
@@ -35,9 +35,9 @@ const notify = function (msg: Message, cb: () => void) {
 
 mq.on('hello/+', notify)
 
-mq.emit('hello/world')
+mq.emit({ topic: 'hello/world' })
 
-mq.emit('hello/world', function (err) {
+mq.emit({ topic: 'hello/world' }, function (err) {
   console.log(err)
 })
 


### PR DESCRIPTION
The `notify` arg in `removeListener` could be optional like in `qlobber.remove`.
Also fixed some broken TS type declarations.