### PR TITLE
Fix emit function declaration

### DIFF
--- a/mqemitter.d.ts
+++ b/mqemitter.d.ts
@@ -1,10 +1,8 @@
-/* eslint no-unused-vars: 0 */
-/* eslint no-undef: 0 */
-/* eslint space-infix-ops: 0 */
-
 /// <reference types="node" />
 
-declare function MQEmitter (options?: MQEmitterOptions): MQEmitter
+declare function MQEmitter(options?: MQEmitterOptions): MQEmitter
+
+export default MQEmitter
 
 interface MQEmitterOptions {
   concurrency?: number
@@ -14,13 +12,13 @@ interface MQEmitterOptions {
   wildcardSome?: string
 }
 
-export type Message = object & { topic: string }
+export type Message = Record<string, any> & { topic: string }
 
 export interface MQEmitter {
   current: number
   concurrent: number
   on(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): this
-  emit(topic: string, callback?: (error?: Error) => void): void
+  emit(message: Message, callback?: (error?: Error) => void): void
   removeListener(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): void
   close(callback: () => void): void
 }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 /* eslint no-undef: 0 */
 
-import { MQEmitter, Message } from '../../mqemitter'
+import MQEmitter, { Message } from '../../mqemitter'
 
 const noop = function () {}
 
@@ -35,9 +35,9 @@ const notify = function (msg: Message, cb: () => void) {
 
 mq.on('hello/+', notify)
 
-mq.emit('hello/world')
+mq.emit({ topic: 'hello/world', payload: 'or any other fields', [Symbol.for('me')]: 42 })
 
-mq.emit('hello/world', function (err) {
+mq.emit({ topic: 'hello/world' }, function (err) {
   console.log(err)
 })
 


### PR DESCRIPTION
Its first argument is an object, not a string:
https://github.com/mcollina/mqemitter/blob/8a023ef14d67554021c2abab1fb002d2d351a66d/mqemitter.js#L110

It would be really nice if you could also bump the version on the npm registry.