### PR TITLE
feat: :sparkles: Factory to standardize the messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ profile*
 
 # lock files
 package-lock.json
+yarn.lock
 
 # generated code
 test/types/*.js

--- a/example.js
+++ b/example.js
@@ -32,13 +32,20 @@ subscribe('hello', a)
 subscribe('hello', b)
 subscribe('hello', c)
 
-mq.emit({ topic: 'hello', payload: 'world' })
+const message = mq.messageFactory('hello', { payload: 'world' })
+mq.emit(message)
 
 a.close()
 b.close()
 c.close()
 
-mq.emit({ topic: 'hello', payload: 'world' })
+// This should be printed at console
+// Error: this message was not created at factory
+//     at MQEmitter.emit (/home/iagocalazans/Documentos/personal/mqemitter/mqemitter.js:120:15)
+//     at Object.<anonymous> (/home/iagocalazans/Documentos/personal/mqemitter/example.js:42:4)
+mq.emit({ topic: 'hello', payload: 'world' }, (err) => {
+  console.log(err)
+})
 
 // const listeners = new Map()
 //

--- a/types/mqemitter.d.ts
+++ b/types/mqemitter.d.ts
@@ -17,6 +17,7 @@ export type Message = Record<string, any> & { topic: string }
 export interface MQEmitter {
   current: number
   concurrent: number
+  messageFactory(topic: string, content?: Record<string, any>): Readonly<Message>
   on(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): this
   emit(message: Message, callback?: (error?: Error) => void): void
   removeListener(topic: string, listener: (message: Message, done: () => void) => void, callback?: () => void): void


### PR DESCRIPTION
Creation of a factory to standardize the messages that enter the Emitter.

@mcollina this functionality needs to be released only in a major update, with the necessary adjustments for that, because all messages will have to be created using the `MQEmitter.prototype.messageFactory` method. Otherwise it returns an `Error`.