### PR TITLE
Remove handler assertion in removeListener

### DIFF
--- a/mqemitter.js
+++ b/mqemitter.js
@@ -83,6 +83,17 @@ MQEmitter.prototype.removeListener = function removeListener (topic, notify, don
   return this
 }
 
+MQEmitter.prototype.removeAllListeners = function removeListener (topic, done) {
+  assert(topic)
+  this._matcher.remove(topic)
+
+  if (done) {
+    setImmediate(done)
+  }
+
+  return this
+}
+
 MQEmitter.prototype.emit = function emit (message, cb) {
   assert(message)
 

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,30 @@ test('removeListener without a callback does not throw', function (t) {
   t.end()
 })
 
+test('removeAllListeners removes listeners', function (t) {
+  const e = mq()
+
+  e.on('hello', function () {
+    t.fail('listener called')
+  })
+
+  e.removeAllListeners('hello', function () {
+    e.emit({ topic: 'hello' }, function () {
+      t.end()
+    })
+  })
+})
+
+test('removeAllListeners without a callback does not throw', function (t) {
+  const e = mq()
+  function fn () {}
+
+  e.on('hello', fn)
+  e.removeAllListeners('hello')
+
+  t.end()
+})
+
 test('set defaults to opts', function (t) {
   const opts = {}
   mq(opts)


### PR DESCRIPTION
Qlobber supports removing all listeners from a topic by not passing a specific listener.

Removed handler assertion in `removeListener` to support this use case.