### PR TITLE
fix: prevent 'Maximum call stack size exceeded' error

### DIFF
--- a/mqemitter.js
+++ b/mqemitter.js
@@ -130,7 +130,9 @@ MQEmitter.prototype._do = function (message, callback) {
   const matches = this._matcher.match(message.topic)
 
   this.current++
-  this._parallel(this, matches, message, callback)
+  setImmediate(
+    this._parallel.bind(this, this, matches, message, callback)
+  )
 
   return this
 }


### PR DESCRIPTION
On very high loads mqemitter `_do` could throw `Maximum call stack size exceeded` error, using `setImmediate` to allow nodejs to clear the stack fixes it