### PR TITLE
chore: migrate to es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "fastparallel": "^2.4.1",
     "qlobber": "^8.0.1"
   }
 }


### PR DESCRIPTION
This PR migrates mqemitter to ES6 and lets go of `fastparallel`.

Kind regards,
Hans